### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.andexert.library">
 
-    <application android:allowBackup="true"
-        android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher"
-        android:theme="@style/AppTheme">
-
-    </application>
+    <application/> 
 
 </manifest>


### PR DESCRIPTION
A library should not have allowBackup="true" or a theme in it's Manifest. It collides with the Apps AndroidManifest.xml and the gradle build fails.

Also Icon and App name isn't required.
