### PR TITLE
Fixed crash on Android 6.0, caused by different number of calls to ca…

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 9
         versionName "1.3"
     }
@@ -23,7 +23,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-annotations:22.0.0'
+    compile 'com.android.support:support-annotations:23.0.1'
 }
 
 if (hasProperty("VERSION_NAME"))

--- a/library/src/main/java/com/andexert/library/RippleView.java
+++ b/library/src/main/java/com/andexert/library/RippleView.java
@@ -158,6 +158,7 @@ public class RippleView extends RelativeLayout {
     public void draw(Canvas canvas) {
         super.draw(canvas);
         if (animationRunning) {
+            canvas.save();
             if (rippleDuration <= timer * frameRate) {
                 animationRunning = false;
                 timer = 0;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName '1.0'
     }
@@ -23,10 +23,10 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.github.traex.rippleeffect:library:1.3'
-    compile 'com.android.support:appcompat-v7:22.0.0'
-    compile 'com.android.support:palette-v7:22.0.0'
-    compile 'com.android.support:recyclerview-v7:22.0.0'
-    compile 'com.android.support:support-v4:22.0.0'
+    compile project(':library')
+    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:palette-v7:23.0.1'
+    compile 'com.android.support:recyclerview-v7:23.0.1'
+    compile 'com.android.support:support-v4:23.0.1'
     compile 'com.squareup.picasso:picasso:2.5.1'
 }


### PR DESCRIPTION
…nvas.restore() / canvas.save(). This may be caused by new restrictions introduced to Marshmallow.

Updated compile, target and support lib versions to 23.
