### PR TITLE
fix a crash in draw with cm13

### DIFF
--- a/library/src/main/java/com/andexert/library/RippleView.java
+++ b/library/src/main/java/com/andexert/library/RippleView.java
@@ -78,6 +78,7 @@ public class RippleView extends RelativeLayout {
     private int rippleColor;
     private int ripplePadding;
     private GestureDetector gestureDetector;
+    private int canvasSaveCount;
     private final Runnable runnable = new Runnable() {
         @Override
         public void run() {
@@ -152,6 +153,7 @@ public class RippleView extends RelativeLayout {
 
         this.setDrawingCacheEnabled(true);
         this.setClickable(true);
+        canvasSaveCount = -1;
     }
 
     @Override
@@ -163,15 +165,19 @@ public class RippleView extends RelativeLayout {
                 timer = 0;
                 durationEmpty = -1;
                 timerEmpty = 0;
-                canvas.restore();
+                if(canvasSaveCount != -1) {
+                    canvas.restoreToCount(canvasSaveCount);
+                    canvasSaveCount = -1;
+                }
                 invalidate();
                 if (onCompletionListener != null) onCompletionListener.onComplete(this);
                 return;
             } else
                 canvasHandler.postDelayed(runnable, frameRate);
 
-            if (timer == 0)
-                canvas.save();
+            if (timer == 0) {
+                canvasSaveCount = canvas.save();
+            }
 
 
             canvas.drawCircle(x, y, (radiusMax * (((float) timer * frameRate) / rippleDuration)), paint);
@@ -493,3 +499,4 @@ public class RippleView extends RelativeLayout {
         }
     }
 }
+


### PR DESCRIPTION
Hi,RippleEffect is great.When I use this lib on my project with Moto X(2014) CM13, It's crashed.Log  as follow:

```
java.lang.IllegalStateException: Underflow in restore - more restores than saves
    at android.graphics.Canvas.native_restore(Native Method)
    at android.graphics.Canvas.restore(Canvas.java:540)
    at com.andexert.library.RippleView.draw(RippleView.java:166)
    at android.view.View.updateDisplayListIfDirty(View.java:15178)
    at android.view.ViewGroup.recreateChildDisplayList(ViewGroup.java:3593)
    at android.view.ViewGroup.dispatchGetDisplayList(ViewGroup.java:3573)
    at android.view.View.updateDisplayListIfDirty(View.java:15138)
```

I think maybe CM13 is still unstable,and the `canvas.restore()` also abnormal, so I make a little change to fix this issue.Using the `canvas.restoreToCount()` as  replacement. Please review my PR,and also thank you for your amazing work.
