### PR TITLE
Avoid calling canvas.restore on Android M

### DIFF
--- a/library/src/main/java/com/andexert/library/RippleView.java
+++ b/library/src/main/java/com/andexert/library/RippleView.java
@@ -33,6 +33,7 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
+import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.ColorRes;
 import android.util.AttributeSet;
@@ -163,7 +164,11 @@ public class RippleView extends RelativeLayout {
                 timer = 0;
                 durationEmpty = -1;
                 timerEmpty = 0;
-                canvas.restore();
+                // There is problem on Android M where canvas.restore() seems to be called automatically
+                // For now, don't call canvas.restore() manually on Android M (API 23)
+                if(Build.VERSION.SDK_INT != 23) {
+                    canvas.restore();
+                }
                 invalidate();
                 if (onCompletionListener != null) onCompletionListener.onComplete(this);
                 return;


### PR DESCRIPTION
Not sure if there is better way of doing this but for now this works on Android M (and other versions)
This also fixes https://github.com/traex/RippleEffect/issues/76
